### PR TITLE
Update requirements for PyMatching 2.0.1

### DIFF
--- a/panqec/analysis.py
+++ b/panqec/analysis.py
@@ -70,7 +70,7 @@ def get_results_df_from_batch(batch_sim, batch_label):
 def get_results_df(
     job_list: List[str],
     output_dir: str,
-    input_dir: str = None,
+    input_dir: Optional[str] = None,
 ) -> pd.DataFrame:
     """Get raw results in DataFrame."""
 

--- a/panqec/codes/base/_stabilizer_code.py
+++ b/panqec/codes/base/_stabilizer_code.py
@@ -529,7 +529,7 @@ class StabilizerCode(metaclass=ABCMeta):
 
         return bs_prod(self.stabilizer_matrix, error)
 
-    def is_stabilizer(self, location: Tuple, stab_type: str = None):
+    def is_stabilizer(self, location: Tuple, stab_type: Optional[str] = None):
         """Returns whether a given location in the coordinate system
         corresponds to a stabilizer or not
         """
@@ -607,7 +607,7 @@ class StabilizerCode(metaclass=ABCMeta):
 
     @abstractmethod
     def get_stabilizer(
-        self, location: Tuple, deformed_axis: str = None
+        self, location: Tuple, deformed_axis: Optional[str] = None
     ) -> Operator:
         """ Returns a stabilizer, formatted as dictionary that assigns a Pauli
         operator ('X', 'Y' or 'Z') to each qubit location in the support of

--- a/panqec/usage.py
+++ b/panqec/usage.py
@@ -140,7 +140,12 @@ class TextPlotter:
     ASCII plotter like matplotlib but in command line.
     """
 
-    def __init__(self, width: int = None, height: int = None):
+    canvas_width: int
+    canvas_height: int
+
+    def __init__(
+        self, width: Optional[int] = None, height: Optional[int] = None
+    ):
         term = shutil.get_terminal_size()
         if height is None:
             self.canvas_height = term.lines - 1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -8,4 +8,4 @@ psutil>=5.8.0
 click>=8.1.2
 Flask>=2.0.1
 ldpc>=0.1.0
-PyMatching==0.2.4
+PyMatching>=2.0.1

--- a/tests/test_deform.py
+++ b/tests/test_deform.py
@@ -22,6 +22,23 @@ def rng():
     return np.random
 
 
+def get_pymatching_distance_matrix(matching):
+    edges = matching.edges()
+    nodes = sorted(
+        set([edge[0] for edge in edges] + [edge[1] for edge in edges])
+    )
+    weights = {
+        (edge[0], edge[1]): edge[2]['weight']
+        for edge in edges
+    }
+    matrix = np.zeros((len(nodes), len(nodes)), dtype=float)
+    for i_1, node_1 in enumerate(nodes):
+        for i_2, node_2 in enumerate(nodes):
+            if (node_1, node_2) in weights:
+                matrix[i_1, i_2] = weights[(i_1, i_2)]
+    return matrix
+
+
 class TestDeformedXZZXErrorModel:
 
     @pytest.mark.parametrize(
@@ -149,8 +166,7 @@ class TestDeformedXZZXErrorModel:
         decoder = SweepMatchDecoder(code, error_model, error_rate)
         assert decoder.matcher.error_model.direction == (0.1, 0.2, 0.7)
         matching = decoder.matcher.matcher_x
-        assert matching.stabiliser_graph.distance(0, 0) == 0
-        distance_matrix = np.array(matching.stabiliser_graph.all_distances)
+        distance_matrix = get_pymatching_distance_matrix(matching)
         n_vertices = int(np.product(code.size))
         assert distance_matrix.shape == (n_vertices, n_vertices)
 
@@ -189,8 +205,7 @@ class TestDeformedXZZXErrorModel:
         decoder = SweepMatchDecoder(code, error_model, error_rate)
         assert decoder.matcher.error_model.direction == (0.4, 0.2, 0.4)
         matching = decoder.matcher.matcher_x
-        assert matching.stabiliser_graph.distance(0, 0) == 0
-        distance_matrix = np.array(matching.stabiliser_graph.all_distances)
+        distance_matrix = get_pymatching_distance_matrix(matching)
         n_vertices = int(np.product(code.size))
         assert distance_matrix.shape == (n_vertices, n_vertices)
 


### PR DESCRIPTION
Pymatching 2.0.1 was released last week, so updated requirements and unit tests that use the new API for the Matching object.
Also fixed some unimportant mypy typing issues that arose from updating to mypy 0.990.