### PR TITLE
Allow using current directory for saving data

### DIFF
--- a/panqec/simulation/_batch_simulation.py
+++ b/panqec/simulation/_batch_simulation.py
@@ -279,6 +279,9 @@ class BatchSimulation():
 
         # Create output directory if it does not exist yet
         output_dir = os.path.dirname(self._output_file)
+        if output_dir == '':
+            output_dir = os.getcwd()
+
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
 


### PR DESCRIPTION
Sometimes we want the data file save to be saved to the current working directory.
This fix allows that. For instance, when doing something like
```
batch_sim = read_input_dict(
    input_dict,
    output_file='mydata.json'
)
```
It will just save `mydata.json` to the current working directory,
as opposed to throwing an error.